### PR TITLE
Initial ideas with Docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+DBUSER=realworld_scotty_user
+DBNAME=realworld_db
+TEST_DBNAME=realworld_test
+
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+
+.DEFAULT_GOAL := help
+
+db-up: ## Sets up the db, runs it as deamon
+	docker-compose up -d
+.PHONY: db-up
+
+db-down: ## Shuts down the DB
+	docker-compose down
+.PHONY: db-down
+
+dbconnect: ## Connect to the database
+	PGPASSWORD=$(PG_PWD) psql -U $(DBUSER) -p 5432 -h localhost -d $(DBNAME)
+.PHONY: dbconnect
+
+run: ## Runs the app
+	ENABLE_HTTPS=False DATABASE_URL="host=localhost dbname=$(DBNAME) user=$(DBUSER) password=$(PG_PWD) port=5432" stack exec realworld-exe
+.PHONY: run
+
+test: ## Runs the test
+	ENABLE_HTTPS=False DATABASE_URL="host=localhost dbname=$(TEST_DBNAME) user=$(DBUSER) password=$(PG_PWD) port=5432" stack test
+.PHONY: test
+
+api-create-user: ## Create user via the API
+	curl --header "Content-Type: application/json; charset=utf-8" \
+	--request POST \
+	--data '{"user":{"username":"Jacob","email":"jake@jake.jake","password":"jakejake"}}' \
+	http://localhost:3000/api/users
+
+api-log-in-user: ## Log in the user
+	curl --header "Content-Type: application/json; charset=utf-8" \
+	--request POST \
+	--data '{"user":{"email":"jake@jake.jake","password":"jakejake"}}' \
+	http://localhost:3000/api/users/login
+
+api-get-user: ## Get a User
+	curl --header "Content-Type: application/json; charset=utf-8; Authorization: Token $(token)" \
+	--request GET \
+	http://localhost:3000/api/user
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.PHONY: help

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.1'
+services:
+  db:
+    image: postgres:latest
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+    - POSTGRES_USER=realworld_scotty_user
+    - POSTGRES_PASSWORD=${PG_PWD}
+    - POSTGRES_DB=realworld_db

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,6 +10,7 @@ import Spec.Common
 import qualified Spec.User as User
 import qualified Spec.Article as Article
 import qualified Spec.Comment as Comment
+import System.Environment
 
 main :: IO ()
 main = withEnv . hspec $ do
@@ -23,8 +24,6 @@ withEnv = bracket startEnv cleanEnv . const
 startEnv :: IO ThreadId
 startEnv = do
   execPGQuery ["drop database if exists realworld_test", "create database realworld_test"]
-  setEnv "DATABASE_URL" "postgresql://127.0.0.1/realworld_test"
-  setEnv "ENABLE_HTTPS" "False"
   setEnv "JWT_EXPIRATION_SECS" "8"
   tId <- forkIO Lib.main
   unlessM healthCheck $ do
@@ -44,6 +43,6 @@ execPGQuery :: [Query] -> IO ()
 execPGQuery qrys =
   bracket acquire release execQuery
   where
-    acquire = connectPostgreSQL "postgresql://127.0.0.1"
+    acquire = connectPostgreSQL "postgresql://realworld_scotty_user:password1@127.0.0.1/postgres"
     release = close
     execQuery conn = forM_ qrys (void . execute_ conn)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,7 +10,6 @@ import Spec.Common
 import qualified Spec.User as User
 import qualified Spec.Article as Article
 import qualified Spec.Comment as Comment
-import System.Environment
 
 main :: IO ()
 main = withEnv . hspec $ do


### PR DESCRIPTION
🚧 NOT yet ready for merge 🚧 
I wanted to submit my ideas before I spend more time on a PR.

First of all: thank you for creating this project. It will help many people looking at how to do REST-like services with authentication.

The intent of this change is to make it super easy for people to get started. I'd like to propose adding the docker compose file, as it will set up a Postgres server in Docker and it's port `5432` will be exposed to the host OS and can talk to it like Postgres would be running on the host.

Also, I'd like to add a Makefile to the project. That could work as a collection of scripts, providing a good intro to the user of what's possible. It even uses a little help menu:

![make-help](https://user-images.githubusercontent.com/80530/41573608-2d7c3d64-7343-11e8-91fa-b26a6c9d9868.png)

I think this Makefile could be used both locally, and on the Travis CI build server as well.

Let me know if you'd consider merging something like this and I'll polish it up a bit more.